### PR TITLE
Auto detect title if provide only http status code 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Http Problem Details
 
-This package is implementation of the [RFC7807 Problem Details for HTTP APIs](rfc-editor.org/rfc/rfc7807.html).
+This package is implementation of the [RFC7807 Problem Details for HTTP APIs](https://tools.ietf.org/html/rfc7807).
 
 ## Instalation
 

--- a/package.json
+++ b/package.json
@@ -39,5 +39,8 @@
     "tsdx": "^0.13.2",
     "tslib": "^2.0.1",
     "typescript": "^3.9.7"
+  },
+  "dependencies": {
+    "http-status-codes": "^1.4.0"
   }
 }

--- a/src/httpProblemDetail.ts
+++ b/src/httpProblemDetail.ts
@@ -1,3 +1,4 @@
+import { getStatusText } from 'http-status-codes';
 import { HttpProblemDetailDefinition } from './httpProblemDetailDefinition';
 import { URI, HttpStatusCode, Serializable } from './types';
 
@@ -7,15 +8,23 @@ const defaultType = 'about:blank';
 
 export class HttpProblemDetail {
   public readonly type: URI;
-  public readonly title: string;
+  public readonly title?: string;
   public readonly status: HttpStatusCode;
   private readonly additionalDetails: Record<string, any>;
 
-  constructor({ type, title, status }: HttpProblemDetailDefinition) {
-    this.type = type || defaultType;
-    this.title = title;
+  constructor({
+    type = defaultType,
+    title,
+    status,
+  }: HttpProblemDetailDefinition) {
+    this.type = type;
     this.status = status;
     this.additionalDetails = {};
+    if (title) {
+      this.title = title;
+    } else if (type === defaultType) {
+      this.title = getStatusText(status);
+    }
   }
 
   public addAdditionalDetail(key: string, value: Serializable) {

--- a/src/httpProblemDetail.ts
+++ b/src/httpProblemDetail.ts
@@ -24,6 +24,10 @@ export class HttpProblemDetail {
       this.title = title;
     } else if (type === defaultType) {
       this.title = getStatusText(status);
+    } else {
+      throw new Error(
+        `You can only omit title when passing ${defaultType} type`
+      );
     }
   }
 
@@ -40,7 +44,7 @@ export class HttpProblemDetail {
     return {
       ...this.additionalDetails,
       status: this.status,
-      title: this.title,
+      title: this.title || null,
       type: this.type,
     };
   }

--- a/src/httpProblemDetailDefinition.ts
+++ b/src/httpProblemDetailDefinition.ts
@@ -2,6 +2,6 @@ import { URI, HttpStatusCode } from './types';
 
 export interface HttpProblemDetailDefinition {
   type?: URI;
-  title: string;
+  title?: string;
   status: HttpStatusCode;
 }

--- a/test/httpProblemDetail.test.ts
+++ b/test/httpProblemDetail.test.ts
@@ -1,21 +1,17 @@
 import { HttpProblemDetail } from '../src';
 import Joi from '@hapi/joi';
 
-export const problemSchema = Joi.object({
-  type: Joi.string(),
-  title: Joi.string(),
-  status: Joi.number().required(),
-}).required();
+const testProblemDetailDefition = {
+  status: 403,
+  title: 'You do not have enough credit.',
+  type: 'https://example.com/probs/out-of-credit',
+};
 
 describe('given HttpProblemDetail', () => {
   describe('when adding additional details', () => {
     let problem: HttpProblemDetail;
     beforeEach(() => {
-      problem = new HttpProblemDetail({
-        status: 403,
-        title: 'You do not have enough credit.',
-        type: 'https://example.com/probs/out-of-credit',
-      });
+      problem = new HttpProblemDetail(testProblemDetailDefition);
     });
 
     it('throw an error when try to overrite status', () => {
@@ -91,13 +87,48 @@ describe('given HttpProblemDetail', () => {
     });
   });
 
-  describe("when doesn't provide a type value", () => {
-    it('should set type as about:blank', () => {
-      const problem = new HttpProblemDetail({
+  describe("when doesn't provide type but pass title", () => {
+    let problem: HttpProblemDetail;
+    beforeEach(() => {
+      problem = new HttpProblemDetail({
         status: 403,
         title: 'You do not have enough credit.',
       });
+    });
+
+    it('set type as about:blank', () => {
       expect(problem.type).toEqual('about:blank');
+    });
+
+    it('use passed title', () => {
+      expect(problem.title).toEqual('You do not have enough credit.');
+    });
+  });
+
+  describe("when doesn't provide type and title", () => {
+    it('define title based on the status', () => {
+      const problem = new HttpProblemDetail({
+        status: 403,
+      });
+      expect(problem.title).toEqual('Forbidden');
+    });
+
+    it('throw an error when use http status code not defined in RFC1945, RFC2616, RFC2518, RFC6585 or RFC7538', () => {
+      expect(() => {
+        new HttpProblemDetail({
+          status: -1,
+        });
+      }).toThrowError();
+    });
+  });
+
+  describe("when doesn't pass title", () => {
+    it('leave title undefined', () => {
+      const problem = new HttpProblemDetail({
+        status: 403,
+        type: 'https://example.com/probs/out-of-credit',
+      });
+      expect(problem.title).toEqual(undefined);
     });
   });
 });

--- a/test/httpProblemDetail.test.ts
+++ b/test/httpProblemDetail.test.ts
@@ -123,12 +123,13 @@ describe('given HttpProblemDetail', () => {
   });
 
   describe("when doesn't pass title", () => {
-    it('leave title undefined', () => {
-      const problem = new HttpProblemDetail({
-        status: 403,
-        type: 'https://example.com/probs/out-of-credit',
-      });
-      expect(problem.title).toEqual(undefined);
+    it('throw an error', () => {
+      expect(() => {
+        new HttpProblemDetail({
+          status: 403,
+          type: 'https://example.com/probs/out-of-credit',
+        });
+      }).toThrowError();
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2994,6 +2994,11 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+http-status-codes@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-1.4.0.tgz#6e4c15d16ff3a9e2df03b89f3a55e1aae05fb477"
+  integrity sha512-JrT3ua+WgH8zBD3HEJYbeEgnuQaAnUeRRko/YojPAJjGmIfGD3KPU/asLdsLwKjfxOmQe5nXMQ0pt/7MyapVbQ==
+
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"


### PR DESCRIPTION
> When "about:blank" is used, the title SHOULD be the same as the
   recommended HTTP status phrase for that code (e.g., "Not Found" for
   404, and so on), although it MAY be localized to suit client
   preferences (expressed with the Accept-Language request header).

https://www.rfc-editor.org/rfc/rfc7807.html#section-4.2

Set `title` as an optional argument in the constructor of `HttpProblemDetail`. When a client doesn't provide both title and type class should detect title based on the status code. I used `http-status-codes` package because it contains required methods 